### PR TITLE
Fixed relative paths (Fixes #17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
-                        <executable>F:/devtools/jdk1.6.0_31/bin/javac</executable>
+                        <executable>${env.JAVA_HOME}/bin/javac</executable>
                     </configuration>
                     <version>2.3.2</version>
                 </plugin>

--- a/src/main/java/com/uttesh/pdfngreport/util/PdfngUtil.java
+++ b/src/main/java/com/uttesh/pdfngreport/util/PdfngUtil.java
@@ -19,6 +19,8 @@ import com.uttesh.pdfngreport.common.Constants;
 import com.uttesh.pdfngreport.common.ImageUtils;
 import com.uttesh.pdfngreport.model.SystemMeta;
 import com.uttesh.pdfngreport.util.xml.ReportData;
+
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -75,7 +77,7 @@ public class PdfngUtil {
     }
     
     private static String absolutify(String relative) {
-		String backSlashes = new java.io.File(relative).getAbsolutePath();
+		String backSlashes = new File(relative).getAbsolutePath();
 		String forwardSlashes = backSlashes.replace('\\', '/');
 		return forwardSlashes;
 	}
@@ -108,6 +110,18 @@ public class PdfngUtil {
         } else {
             exceptionPage = Constants.SHOW;
         }
+        
+        File logoFilepath = new File(logoFile);
+        if (logoFilepath.exists()) {
+        	// This isn't really necessary; absolutify won't do anything to paths that are already absolute
+        	if (logoFilepath.isAbsolute())
+                reportData.setLogoFile(logoFile);
+        	else
+        		reportData.setLogoFile(absolutify(logoFile));
+        } else {
+        	System.err.println("[ERROR] Logo file located at '" + absolutify(logoFile) + "' cannot be found! Disabling logo...");
+        	logo = "hide";
+        }
 
         InputStream exceptionIcon = getClass().getClassLoader().getResourceAsStream(Constants.Icons.EXCEPTION_ICON);
 
@@ -128,7 +142,6 @@ public class PdfngUtil {
         reportData.setTitleAlign(titleAlign);
         reportData.setReportLocation(reportLocation);
         reportData.setChart(chart);
-        reportData.setLogoFile(logoFile);
         reportData.setLogo(logo);
         reportData.setLogoAlign(logoAlign);
         reportData.setExceptionPage(exceptionPage);

--- a/src/main/java/com/uttesh/pdfngreport/util/PdfngUtil.java
+++ b/src/main/java/com/uttesh/pdfngreport/util/PdfngUtil.java
@@ -65,12 +65,20 @@ public class PdfngUtil {
     }
 
     public static String getReportLocation() {
-        String location = System.getProperty(Constants.SystemProps.REPORT_OUPUT_DIR);
-        if (location == null || location.trim().length() == 0) {
-            location = (String) PDFCache.getConfig(Constants.SystemProps.REPORT_OUPUT_DIR);
-        }
-        return location;
+        String outputDir = System.getProperty(Constants.SystemProps.REPORT_OUPUT_DIR);
+    	if (outputDir == null || outputDir.trim().length() == 0) {
+    		String configOption = (String) PDFCache.getConfig(Constants.SystemProps.REPORT_OUPUT_DIR);
+    		return absolutify(configOption);
+    	} else {
+    		return absolutify(outputDir);
+    	}
     }
+    
+    private static String absolutify(String relative) {
+		String backSlashes = new java.io.File(relative).getAbsolutePath();
+		String forwardSlashes = backSlashes.replace('\\', '/');
+		return forwardSlashes;
+	}
 
     public void populateReportDataProperties(ReportData reportData) throws Exception {
         String reportTitle = (String) PDFCache.getConfig(Constants.SystemProps.REPORT_TITLE_PROP);


### PR DESCRIPTION
It actually took a while to figure out where the paths were being incorrectly processed, but once I did, it was a pretty easy fix. Just needed to create absolute paths.

Also, the filepath-separator conversion in this program is pretty weird. That's why that ".replace('\\, '/')" is there.

Fixes #17 